### PR TITLE
Bugfix and unified fix for #6 and #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ Any devices with this tag will not be bridged, and will be excluded from the log
 
 #### Homebridge.Include
 
-Only used in conjunction with the `opt_in` configuration option above, this marks a device to be included in opt-in mode, while all other devices are skipped.
+This tag has two different but related purposes. Essentially, it lets you include a device on the bridge that would have otherwise been excluded.
+
+1. If in the Z-Way GUI you set "Permanently hide this element", then it will not be bridged by Homebridge by default. If you want it to be hidden in Z-Way yet visible in Homebridge, you can use the `Homebridge.Include` tag to override this behavior.
+
+2. Used in conjunction with the `opt_in` configuration option above, this marks a device to be included in opt-in mode, while all devices without the tag are skipped.
+
+Note that if both `Homebridge.Skip` and `Homebridge.Include` are specified on the same device that `Homebridge.Skip` wins--_unless_ you have set the `opt_in` configuration option. This is useful for troubleshooting or development: you can have a "production" instance of Homebridge running that skips a troublesome device (with `opt_in` false) and a second instance for testing running with `opt_in` true that will pick up the device regardless of the `Skip` tag.
 
 #### Homebridge.IsPrimary
 

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ ZWayServerPlatform.prototype = {
             var groupedDevices = {};
             for(var i = 0; i < devices.length; i++){
                 var vdev = devices[i];
-                if(this.getTagValue("Skip")) { debug("Tag says skip!"); continue; }
+                if(this.getTagValue("Skip") || vdev.permanently_hidden) { debug("Tag says skip!"); continue; }
                 if(this.opt_in && !this.getTagValue(vdev, "Include")) continue;
 
                 var gdid = this.getTagValue(vdev, "Accessory.Id");
@@ -202,7 +202,7 @@ ZWayServerPlatform.prototype = {
                     var pd = gd.devices[gd.primary];
                     var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
                     // Skip subdevice if needed
-                    if(this.getTagValue(pd, "Skip")) {debug("Tag says skip!"); continue; }
+                    if(this.getTagValue(pd, "Skip") || pd.permanently_hidden) { debug("Tag says skip!"); continue; }
                     accessory = new ZWayServerAccessory(name, gd, that);
                 }
                 else for(var ti = 0; ti < primaryDeviceClasses.length; ti++){
@@ -212,7 +212,8 @@ ZWayServerPlatform.prototype = {
                         var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
                         //debug("Using primary device with type " + primaryDeviceClasses[ti] + ", " + name + " (" + pd.id + ") as primary.");
                         // Skip subdevice if needed
-                        if(this.getTagValue(pd, "Skip")) { debug("Tag says skip!"); continue; }
+                        debug("Skip: " & pd.permanently_hidden);
+                        if(this.getTagValue(pd, "Skip") || pd.permanently_hidden) { debug("Tag says skip!"); continue; }
                         accessory = new ZWayServerAccessory(name, gd, that);
                         break;
                     }

--- a/index.js
+++ b/index.js
@@ -201,6 +201,8 @@ ZWayServerPlatform.prototype = {
                 if(gd.primary !== undefined){
                     var pd = gd.devices[gd.primary];
                     var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
+                    // Skip subdevice if needed
+                    if(this.getTagValue(pd, "Skip")) {debug("Tag says skip!"); continue; }
                     accessory = new ZWayServerAccessory(name, gd, that);
                 }
                 else for(var ti = 0; ti < primaryDeviceClasses.length; ti++){
@@ -209,6 +211,8 @@ ZWayServerPlatform.prototype = {
                         var pd = gd.devices[gd.primary];
                         var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
                         //debug("Using primary device with type " + primaryDeviceClasses[ti] + ", " + name + " (" + pd.id + ") as primary.");
+                        // Skip subdevice if needed
+                        if(this.getTagValue(pd, "Skip")) { debug("Tag says skip!"); continue; }
                         accessory = new ZWayServerAccessory(name, gd, that);
                         break;
                     }

--- a/index.js
+++ b/index.js
@@ -408,7 +408,7 @@ if(!vdev) debug("ERROR: vdev passed to getVDevServices is undefined!");
                 } else if(stype === "GarageDoorOpener"){
                     services.push(new Service.GarageDoorOpener(vdev.metrics.title, vdev.id));
                 } else if(stype === "Window"){
-                    services.push(new Service.GarageDoorOpener(vdev.metrics.title, vdev.id));
+                    services.push(new Service.Window(vdev.metrics.title, vdev.id));
                 } else {
                     services.push(new Service.Door(vdev.metrics.title, vdev.id));
                 }

--- a/index.js
+++ b/index.js
@@ -116,6 +116,24 @@ ZWayServerPlatform.prototype = {
         return false;
     }
     ,
+    isVDevBridged: function(vdev){
+        var isBridged;
+        var isTaggedSkip = this.getTagValue(vdev, "Skip");
+        var isTaggedInclude  = this.getTagValue(vdev, "Include");
+
+        if(this.opt_in) isBridged = false; else isBridged = true; // Start with the initial bias
+        if(vdev.permanently_hidden) isBridged = false;
+        if(isTaggedInclude) isBridged = true; // Include overrides permanently_hidden
+        if(isTaggedSkip) isBridged = false; // Skip overrides Include...
+        if(this.opt_in && isTaggedInclude) isBridged = true; // ...unless we're in opt_in mode, where Include always wins.
+
+        if(!isBridged && !this.opt_in){
+            debug("Device " + vdev.id + " skipped! ");
+            debug({"permanently_hidden": vdev.permanently_hidden, "Skip": isTaggedSkip, "Include": isTaggedInclude, "opt_in": this.opt_in});
+        }
+        return isBridged;
+    }
+    ,
     accessories: function(callback) {
         debug("Fetching Z-Way devices...");
 
@@ -144,8 +162,8 @@ ZWayServerPlatform.prototype = {
             var groupedDevices = {};
             for(var i = 0; i < devices.length; i++){
                 var vdev = devices[i];
-                if(this.getTagValue("Skip") || vdev.permanently_hidden) { debug("Tag says skip!"); continue; }
-                if(this.opt_in && !this.getTagValue(vdev, "Include")) continue;
+
+                if(!this.isVDevBridged(vdev)) continue;
 
                 var gdid = this.getTagValue(vdev, "Accessory.Id");
                 if(!gdid){
@@ -201,8 +219,6 @@ ZWayServerPlatform.prototype = {
                 if(gd.primary !== undefined){
                     var pd = gd.devices[gd.primary];
                     var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
-                    // Skip subdevice if needed
-                    if(this.getTagValue(pd, "Skip") || pd.permanently_hidden) { debug("Tag says skip!"); continue; }
                     accessory = new ZWayServerAccessory(name, gd, that);
                 }
                 else for(var ti = 0; ti < primaryDeviceClasses.length; ti++){
@@ -211,9 +227,6 @@ ZWayServerPlatform.prototype = {
                         var pd = gd.devices[gd.primary];
                         var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
                         //debug("Using primary device with type " + primaryDeviceClasses[ti] + ", " + name + " (" + pd.id + ") as primary.");
-                        // Skip subdevice if needed
-                        debug("Skip: " & pd.permanently_hidden);
-                        if(this.getTagValue(pd, "Skip") || pd.permanently_hidden) { debug("Tag says skip!"); continue; }
                         accessory = new ZWayServerAccessory(name, gd, that);
                         break;
                     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-zway",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "homebridge-plugin for ZWay Server and RaZBerry",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now should correctly `Skip`—well, anything really. And now respects `permanently_hidden`, unless overridden by `Include`. And if `Include` and `Skip` are both tagged, `Include` only wins if in `opt_in` mode, which helps for debugging/troubleshooting.