### PR TITLE
Fix for 2 vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,11 @@
     "HomeKit"
   ],
   "engines": {
-   "node": ">=0.12.0",
-   "homebridge": ">=0.2.5"
- },
-
+    "node": ">=0.12.0",
+    "homebridge": ">=0.2.5"
+  },
   "dependencies": {
-    "request": "2.65.x",
+    "request": "2.74.0",
     "q": "1.4.x",
     "debug": "^2.2.0",
     "tough-cookie": "^2.2.0"


### PR DESCRIPTION
homebridge-zway currently has a 2 vulnerable dependency paths, introducing 2 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/SphtKr/homebridge-zway) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
