### PR TITLE
This is almost certainly also required.

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,6 +246,7 @@ ZWayServerPlatform.prototype = {
             "switchMultilevel",
             "switchBinary",
             "sensorBinary.Door/Window",
+            "sensorBinary.alarm_door",
             "sensorBinary.alarmSensor_flood",
 
             // | Possible regression, this couldn't become a primary before, but it's needed for some LeakSensors...


### PR DESCRIPTION
Tested this with one of my devices by disabling the `door-window`
device and leaving only its `alarm_door` device, and it seems to work.