### PR TITLE
Fixes hang on start with duplicate names

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,14 +339,14 @@ ZWayServerPlatform.prototype = {
                 var accessory = null;
                 if(gd.primary !== undefined){
                     var pd = gd.devices[gd.primary];
-                    var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
+                    var name = pd.metrics && pd.metrics.title ? pd.metrics.title + " (" + pd.id + ")" : pd.id;
                     accessory = new ZWayServerAccessory(name, gd, that);
                 }
                 else for(var ti = 0; ti < primaryDeviceClasses.length; ti++){
                     if(gd.types[primaryDeviceClasses[ti]] !== undefined){
                         gd.primary = gd.types[primaryDeviceClasses[ti]];
                         var pd = gd.devices[gd.primary];
-                        var name = pd.metrics && pd.metrics.title ? pd.metrics.title : pd.id;
+                        var name = pd.metrics && pd.metrics.title ? pd.metrics.title + " (" + pd.id + ")" : pd.id;
                         //debug("Using primary device with type " + primaryDeviceClasses[ti] + ", " + name + " (" + pd.id + ") as primary.");
                         accessory = new ZWayServerAccessory(name, gd, that);
                         break;


### PR DESCRIPTION
In the current version homebridge hangs on startup if there are multiple devices that use the same name. This is a common setup. I named all my Fibaro Dimmers *Light* for example, because they are in different rooms so I can still know them apart.

This PR fixes the issue by adding the `id` to the name: `<Name> (<id>)`.