### PR TITLE
Fix Thermostat Service (TemperatureDisplayUnits)

### DIFF
--- a/index.js
+++ b/index.js
@@ -961,6 +961,8 @@ ZWayServerAccessory.prototype = {
                 debug("Getting value for " + vdev.metrics.title + ", characteristic \"" + cx.displayName + "\"...");
                 callback(false, Characteristic.TemperatureDisplayUnits.CELSIUS);
             });
+
+            // breaks the temperature control UI. I think it's sinnce iOS13 
             // cx.setProps({
             //     perms: [Characteristic.Perms.READ]
             // });

--- a/index.js
+++ b/index.js
@@ -961,9 +961,9 @@ ZWayServerAccessory.prototype = {
                 debug("Getting value for " + vdev.metrics.title + ", characteristic \"" + cx.displayName + "\"...");
                 callback(false, Characteristic.TemperatureDisplayUnits.CELSIUS);
             });
-            cx.setProps({
-                perms: [Characteristic.Perms.READ]
-            });
+            // cx.setProps({
+            //     perms: [Characteristic.Perms.READ]
+            // });
             return cx;
         }
 


### PR DESCRIPTION
by setting this permission:

perms: [Characteristic.Perms.READ]

the thermostat view stops working. I think there was a change since iOS13 in homekit api and we need write perms. But I don't know why. For me it works now.

